### PR TITLE
Configureable Rspec command

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,5 @@
 const vscode = require('vscode')
 const {exec} = require('child_process')
-const {basename} = require('path')
 
 let lastCommand
 
@@ -17,7 +16,7 @@ function activate(context) {
 exports.activate = activate
 
 function runAll() {
-	executeCommand(buildCommand(`bundle exec rspec ${getFilePath()}`))
+	executeCommand(buildCommand(`${rspecCommand()} ${getFilePath()}`))
 }
 
 function runAgain() {
@@ -30,7 +29,7 @@ function runAgain() {
 
 function runCurrent() {
 	let line = vscode.window.activeTextEditor.selection.active.line
-	executeCommand(buildCommand(`bundle exec rspec ${getFilePath()}:${line}`))
+	executeCommand(buildCommand(`${rspecCommand()} ${getFilePath()}:${line}`))
 }
 
 // Try to return relative file path, fallback to full qualified.
@@ -67,4 +66,8 @@ function buildCommand(code) {
 
 function executeCommand(command) {
 	exec(command)
+}
+
+function rspecCommand() {
+	return vscode.workspace.getConfiguration('rspec-iterm').get('rspecCommand');
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Run rspec command in foreground (switch to iterm on activation)."
+				},
+				"rspec-iterm.rspecCommand": {
+					"type": "string",
+					"default": "bundle exec rspec",
+					"description": "Rspec command to use, default: `bundle exec rspec`"
 				}
 			}
 		},


### PR DESCRIPTION
Thanks for the extension, was thinking of writing one because existing rspec runner running my spec in vscode terminal, it makes things hard to see and debug. Funny then I found this one! 

This small PR will enable the command to be configurable. I have aliased my `rspec` command to run rspec alongside with spring (or so people can configure it to run rspec on top of spring)