### PR TITLE
Line is Off by one

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -28,7 +28,7 @@ function runAgain() {
 }
 
 function runCurrent() {
-	let line = vscode.window.activeTextEditor.selection.active.line
+	let line = vscode.window.activeTextEditor.selection.active.line + 1
 	executeCommand(buildCommand(`${rspecCommand()} ${getFilePath()}:${line}`))
 }
 


### PR DESCRIPTION
I found that running the rspec on the current line if off by 1 because vscode API for Position is starting from 0

https://code.visualstudio.com/api/references/vscode-api#Position

> The zero-based line value.